### PR TITLE
feat: Different annotations for decimal, integer and float

### DIFF
--- a/addon/initializers/data-adapter.js
+++ b/addon/initializers/data-adapter.js
@@ -186,11 +186,14 @@ class SemanticDataAdapter extends DebugDataAdapter {
   }
 }
 
-export default {
-  name: "data-adapter",
-  after: "rdf-store",
-  initialize( application ) {
-    if( env.rdfStore.enableDataAdapter )
-      application.register('data-adapter:main', SemanticDataAdapter);
+export function initialize(application) {
+  if (env.rdfStore.enableDataAdapter) {
+    application.register('data-adapter:main', SemanticDataAdapter);
   }
+}
+
+export default {
+  name: 'data-adapter',
+  after: 'rdf-store',
+  initialize,
 };

--- a/addon/models/semantic-model.js
+++ b/addon/models/semantic-model.js
@@ -110,8 +110,14 @@ function calculatePropertyValue(target, propertyName) {
           .match(target.uri, predicate, undefined, graph)
           .map(({ object }) => object.value);
       break;
+    case "decimal":
+      value = response && parseFloat(response.value);
+      break;
     case "integer":
       value = response && parseInt(response.value);
+      break;
+    case "float":
+      value = response && parseFloat(response.value);
       break;
     case "boolean":
       if (response === undefined) {
@@ -270,8 +276,14 @@ function property(options = {}) {
               [...stringsToAdd].map( (str) => new rdflib.Statement(this.uri, predicate, new rdflib.Literal(str), graph)));
 
             break;
-          case "integer":
+          case "decimal":
             setRelationObject(new rdflib.Literal(value, null, XSD("decimal")));
+            break;
+          case "integer":
+            setRelationObject(new rdflib.Literal(value, null, XSD("integer")));
+            break;
+          case "float":
+            setRelationObject(new rdflib.Literal(value, null, XSD("float")));
             break;
           case "boolean":
             setRelationObject(new rdflib.Literal(value ? "true" : "false", null, XSD("boolean")));
@@ -381,12 +393,34 @@ function uri(options = {}) {
 
 /**
  *
+ * Creates an decimal property
+ *
+ * @param {Object} options Options
+ */
+function decimal(options = {}) {
+  options.type = "decimal";
+  return property(options);
+}
+
+/**
+ *
  * Creates an integer property
  *
  * @param {Object} options Options
  */
 function integer(options = {}) {
   options.type = "integer";
+  return property(options);
+}
+
+/**
+ *
+ * Creates a float property
+ *
+ * @param {Object} options Options
+ */
+function float(options = {}) {
+  options.type = "float";
   return property(options);
 }
 
@@ -601,5 +635,5 @@ function solid(options) {
 }
 
 export default SemanticModel;
-export { property, string, stringSet, uri, integer, boolean, dateTime, hasMany, belongsTo, term, solid };
+export { property, string, stringSet, uri, decimal, integer, float, boolean, dateTime, hasMany, belongsTo, term, solid };
 export { rdfType, defaultGraph, autosave };

--- a/app/models/semantic-model.js
+++ b/app/models/semantic-model.js
@@ -1,3 +1,3 @@
 export {default} from "ember-solid/models/semantic-model";
-export { property, string, integer, dateTime, hasMany, belongsTo, term, solid } from "ember-solid/models/semantic-model";
+export { property, string, decimal, integer, float, dateTime, hasMany, belongsTo, term, solid } from "ember-solid/models/semantic-model";
 export { rdfType, defaultGraph, autosave } from "ember-solid/models/semantic-model";

--- a/tests/unit/initializers/data-adapter-test.js
+++ b/tests/unit/initializers/data-adapter-test.js
@@ -1,7 +1,7 @@
 import Application from '@ember/application';
 
 import config from 'dummy/config/environment';
-import { initialize } from 'dummy/initializers/my-dummy-test';
+import { initialize } from 'dummy/initializers/data-adapter';
 import { module, test } from 'qunit';
 import Resolver from 'ember-resolver';
 import { run } from '@ember/runloop';


### PR DESCRIPTION
Before, there was only one kind of number annotation being `integer()` which was implemented to be `xsd:decimal`.
This PR implements all 3 type of numbers as following so we can also have a float annotation.
- `decimal()` for `xsd:decimal`
- `integer()` for `xsd:integer`
- `float()` for `xsd:float`