### PR TITLE
fix: Pass filled in custom provider instead of undefined as parameter

### DIFF
--- a/blueprints/ember-solid/files/app/templates/login.hbs
+++ b/blueprints/ember-solid/files/app/templates/login.hbs
@@ -7,8 +7,8 @@
   <li><button role="button" {{on "click" (fn this.login "https://pod.inrupt.com/")}}>inrupt</button></li>
   {{#let "" as |provider|}}
     <li>
-      <Input @value={{provider}} placeholder="https://your-own-pod-url.org/"/>
-      <button role="button" {{on "click" (fn this.login provider)}}>Custom Login</button>
+      <Input @value={{this.provider}} placeholder="https://your-own-pod-url.org/"/>
+      <button role="button" {{on "click" (fn this.login this.provider)}}>Custom Login</button>
     </li>
   {{/let}}
 </ul>


### PR DESCRIPTION
This change was required to make sure that the parameter of `this.login` was not undefined.