### PR TITLE
fix: Resolve exception on destroying object having a URI property

### DIFF
--- a/addon/models/semantic-model.js
+++ b/addon/models/semantic-model.js
@@ -280,7 +280,7 @@ function property(options = {}) {
             setRelationObject(new rdflib.Literal(value.toUTCString(), null, XSD("dateTime")));
             break;
           case "uri":
-            setRelationObject(new rdflib.NamedNode(value));
+            setRelationObject(value ? new rdflib.NamedNode(value) : undefined);
             break;
           case "belongsTo":
             const oldValue = this[propertyName];


### PR DESCRIPTION
When doing a `model.destroy()` when that model contains a `uri()` property, it tries to set that property equal to `null` before deleting the model object itself.
That would however results in a `setRelationObject(new rdflib.NamedNode(null));`, mind the inner `null`, causing `Uncaught TypeError: Cannot read properties of null (reading 'value')`.
This PR resolves this.