### PR TITLE
Add Documentation for Ember-Solid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,113 @@
-solid-addon
-==============================================================================
+# A Solid bridge to Ember
+Ember-Solid is an ember addon which creates a bridge between ember and solid,
+allowing data to be pulled from a solid pod and used in an ember environment.
+It is a drop-in replacement for ember-data.
 
-[Short description of the addon.]
-
-
-Compatibility
-------------------------------------------------------------------------------
+# contents
+ - [tutorial](#tutorial)
+ - [how to](#how-to's)
+ - [reference](#reference)
+ - [discussion](#discussion)
+## Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
 * Node.js v12 or above
 
 
-Installation
-------------------------------------------------------------------------------
+## tutorial
+A practical example of Ember-Solid.
+In this tutorial we will make a simple page which displays authors.
+The authors will be pulled from a users solid-pod and displayed using ember.
+#### result 
+#### setting up the environment
+Navigate to the directory where you want to set up your project.
+In a terminal, enter `ember new tutorial`.
+followed by `ember install https://github.com/redpencilio/ember-solid`
+and `ember generate ember-solid`
+
+first go into `templates/applications.hbs` and change it to this 
+```hbs
+{{page-title "Tutorial on Ember-Solid"}}
+<h1>tutorial</h1>
+<LinkTo @route="authors">Authors</LinkTo>
+{{outlet}}
+```
+
+Now in a terminal type 
+`ember g route authors`
+
+in `routes/authors.js` put
+```js
+import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
+export default class AuthorsRoute extends Route {
+  @service solidAuth;
+  @service store;
+  async model() {
+    await this.solidAuth.ensureLogin();
+    await this.store.fetchGraphForType("author");
+    return this.store.all("author");
+  }
+}
 
 ```
-npm remove ember-data
-ember install ember-solid-store
+And in `templates/authors.hbs` write
+```hbs
+{{page-title "Authors"}}
+<h2>Authors</h2>
+<ul>
+{{#each @model as |author|}}
+  <li>{{author.givenName}}  {{author.familyName}}</li>
+{{/each}}
+</ul>
+{{outlet}}
 ```
 
+in a terminal type `ember g model author`
+and then in `models/authors` put
+```js
+import SemanticModel, {
+  solid,
+  string,
+  integer,
+  hasMany,
+  belongsTo
+} from "ember-solid/models/semantic-model";
 
-Usage
-------------------------------------------------------------------------------
+@solid({
+  defaultStorageLocation: '/private/tests/my-books.ttl', // default location in solid pod
+  private: true, // is this private info for the user?
+  type: 'http://schema.org/Person', // optional, defining NS is good enough if this is derived from the namespace.
+  namespace: 'http://schema.org/', // define a namespace for properties.  http://schema.org/ is a good starting point for finding definitions.  No clue? use 'ext'.
+})
+export default class Author extends SemanticModel {
+  @string()
+  givenName;
 
-[Longer description of how to use the addon in apps.]
+  @string()
+  familyName;
 
 
-Contributing
-------------------------------------------------------------------------------
+}
+```
+
+Now we should be able to log in and see the Authors stored in our solidpod
+
+
+## how-to's
+
+## reference
+
+## discussion
+
+### Solid
+
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is a drop-in replacement for ember-data.
 
 # contents
  - [tutorial](#tutorial)
- - [how to](#how-to's)
+ - [how to](#how-to)
  - [reference](#reference)
  - [discussion](#discussion)
 ## Compatibility
@@ -95,7 +95,7 @@ export default class Author extends SemanticModel {
 Now we should be able to log in and see the Authors stored in our solidpod
 
 
-## how-to's
+## how-to
 
 ### model a semantic model
 ```js

--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
 # A Solid bridge to Ember
+
 Ember-Solid is an ember addon which creates a bridge between ember and solid,
 allowing data to be pulled from a solid pod and used in an ember environment.
 It is a drop-in replacement for ember-data.
 
 # contents
- - [tutorial](#tutorial)
- - [how to](#how-to)
- - [reference](#reference)
- - [discussion](#discussion)
+
+- [tutorial](#tutorial)
+- [how to](#how-to)
+- [reference](#reference)
+- [discussion](#discussion)
+
 ## Compatibility
 
 * Ember.js v3.24 or above
 * Ember CLI v3.24 or above
 * Node.js v12 or above
 
-
 ## tutorial
+
 A practical example of Ember-Solid.
 In this tutorial we will make a simple page which displays authors.
 The authors will be pulled from a users solid-pod and displayed using ember.
-#### result 
+
+#### result
+
 #### setting up the environment
+
 Navigate to the directory where you want to set up your project.
 In a terminal, enter `ember new tutorial`.
 followed by `ember install https://github.com/redpencilio/ember-solid`
 and `ember generate ember-solid`
 
-first go into `templates/application.hbs` and change it to this 
+first go into `templates/application.hbs` and change it to this
+
 ```html
 {{page-title "Tutorial on Ember-Solid"}}
 <h1>tutorial</h1>
@@ -34,16 +41,19 @@ first go into `templates/application.hbs` and change it to this
 {{outlet}}
 ```
 
-Now in a terminal type 
+Now in a terminal type
 `ember g route author`
 
 in `routes/author.js` put
+
 ```js
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
+
 export default class AuthorRoute extends Route {
   @service solidAuth;
   @service store;
+
   async model() {
     await this.solidAuth.ensureLogin();
     await this.store.fetchGraphForType("author");
@@ -52,20 +62,23 @@ export default class AuthorRoute extends Route {
 }
 
 ```
+
 And in `templates/author.hbs` write
+
 ```html
 {{page-title "Authors"}}
 <h2>Authors</h2>
 <ul>
-{{#each @model as |author|}}
-  <li>{{author.givenName}}  {{author.familyName}}</li>
-{{/each}}
+  {{#each @model as |author|}}
+  <li>{{author.givenName}} {{author.familyName}}</li>
+  {{/each}}
 </ul>
 {{outlet}}
 ```
 
 in a terminal type `ember g model author`
 and then in `models/author.js` put
+
 ```js
 import SemanticModel, {
   solid,
@@ -94,10 +107,10 @@ export default class Author extends SemanticModel {
 
 Now we should be able to log in and see the Authors stored in our solidpod
 
-
 ## how-to
 
 ### model a semantic model
+
 ```js
 import SemanticModel, {
   solid,
@@ -121,12 +134,14 @@ export default class ourSemanticModel extends SemanticModel {
 ```
 
 ### initiate the authentication service
+
 ```js
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class ApplicationRoute extends Route {
   @service solidAuth;
+
   async beforeModel() {
     await this.solidAuth.ensureLogin();
   }
@@ -143,6 +158,7 @@ import { inject as service } from '@ember/service';
 export default class ApplicationRoute extends Route {
   @service solidAuth;
   @service store;
+
   async model() {
     await this.solidAuth.ensureLogin();
     await this.store.fetchGraphForType("author");
@@ -162,11 +178,13 @@ import { inject as service } from '@ember/service';
 export default class ApplicationRoute extends Route {
   @service solidAuth;
   @service store;
+
   async model() {
     await this.solidAuth.ensureLogin();
     await this.store.fetchGraphForType("author");
     return this.store.all("author");
   }
+
   async afterModel(model) {
     model.forEach((author) => {
       author.givenName = "new name";
@@ -178,7 +196,7 @@ export default class ApplicationRoute extends Route {
 ```
 
 ### delete data locally
-  
+
   ```js
   import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
@@ -186,11 +204,13 @@ import { inject as service } from '@ember/service';
 export default class ApplicationRoute extends Route {
   @service solidAuth;
   @service store;
+
   async model() {
     await this.solidAuth.ensureLogin();
     await this.store.fetchGraphForType("author");
     return this.store.all("author");
   }
+
   async afterModel(model) {
     model.forEach((author) => {
       author.destroy();
@@ -201,7 +221,6 @@ export default class ApplicationRoute extends Route {
 
 ```
 
-
 ### update the solid store
 
 ```js
@@ -211,11 +230,13 @@ import { inject as service } from '@ember/service';
 export default class ApplicationRoute extends Route {
   @service solidAuth;
   @service store;
+
   async model() {
     await this.solidAuth.ensureLogin();
     await this.store.fetchGraphForType("author");
     return this.store.all("author");
   }
+
   async afterModel(model) {
     model.forEach((author) => {
       author.givenName = "new name";
@@ -227,54 +248,64 @@ export default class ApplicationRoute extends Route {
 
 ```
 
-
 ## reference
 
 ### semantic decorators
 
-
 #### `@rdfType(typeUri)`
-Marks a class as representing a specific RDF type. This decorator assigns an RDF type URI to the class, which is used when instances of the class are stored or retrieved from the RDF store.
+
+Marks a class as representing a specific RDF type. This decorator assigns an RDF type URI to the class, which is used
+when instances of the class are stored or retrieved from the RDF store.
 
 ```javascript
-@rdfType('http://example.com/Type')
-class MyModel extends SemanticModel {
+@rdfType('http://example.com/Type') class MyModel extends SemanticModel {
   // Class definition
 }
 ```
 
 #### `@defaultGraph(graphUri)`
-Specifies the default graph URI for all instances of the class. This is used to determine where in the RDF store the instances should be placed or retrieved from by default.
+
+Specifies the default graph URI for all instances of the class. This is used to determine where in the RDF store the
+instances should be placed or retrieved from by default.
 
 ```javascript
-@defaultGraph('http://example.com/graph')
-class MyModel extends SemanticModel {
+@defaultGraph('http://example.com/graph') class MyModel extends SemanticModel {
   // Class definition
 }
 ```
 
 #### `@autosave(boolean)`
-Enables or disables automatic saving of instances to the RDF store upon changes. When set to `true`, any change to an instance its properties will automatically trigger an update in the RDF store.
+
+Enables or disables automatic saving of instances to the RDF store upon changes. When set to `true`, any change to an
+instance its properties will automatically trigger an update in the RDF store.
 
 ```javascript
-@autosave(true)
-class MyModel extends SemanticModel {
+@autosave(true) class MyModel extends SemanticModel {
   // Class definition
 }
 ```
 
 #### `@solid(options)`
-Configures the solid integration with the class. This decorator can be used to set up a model class for use with Solid data pods.
+
+Configures the solid integration with the class. This decorator can be used to set up a model class for use with Solid
+data pods.
 
 ```javascript
-@solid({ defaultStorageLocation: '/private/myLocation', private: true, type: 'http://example.com/Type', namespace: 'http://example.com/' })
-class MyModel extends SemanticModel {
+@solid({
+  defaultStorageLocation: '/private/myLocation',
+  private: true,
+  type: 'http://example.com/Type',
+  namespace: 'http://example.com/'
+}) class MyModel extends SemanticModel {
   // Class definition
 }
 ```
 
 #### Property Decorators
-The file also introduces a set of property decorators, which are used to define the properties of the model classes. These decorators specify the type of the property, how it relates to RDF predicates, and other options like whether the property is a relation to another model.
+
+The file also introduces a set of property decorators, which are used to define the properties of the model classes.
+These decorators specify the type of the property, how it relates to RDF predicates, and other options like whether the
+property is a relation to another model.
 
 - `@property(options)`: Generic property decorator to define a model property.
 - `@string(options)`: Defines a string property.
@@ -289,7 +320,8 @@ The file also introduces a set of property decorators, which are used to define 
 - `@belongsTo(options)`: Defines a relation to a single instance of another model.
 - `@term(options)`: Defines a property that holds a term (NamedNode, BlankNode, or Literal).
 
-Each property decorator is used by specifying it above the property definition in the model class, providing options to configure the property's behavior and how it maps to RDF data.
+Each property decorator is used by specifying it above the property definition in the model class, providing options to
+configure the property's behavior and how it maps to RDF data.
 
 ```javascript
 class MyModel extends SemanticModel {
@@ -307,7 +339,9 @@ The `rdf-store` serves as the primary interface for interacting with Solid stora
 It provides methods to interact with the data from a Solid pod.
 
 #### `create(model, options = {})`
-- **Description**: Creates an instance of a model with a specific URI and saves it in the cache. If an instance with the same URI already exists in the cache, it returns the existing instance instead of creating a new one.
+
+- **Description**: Creates an instance of a model with a specific URI and saves it in the cache. If an instance with the
+  same URI already exists in the cache, it returns the existing instance instead of creating a new one.
 - **Usage**: `storeService.create('modelName', { uri: 'resourceUri' });`
 - **Parameters**:
   - `model` (String): Model to create an instance of.
@@ -315,13 +349,16 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: An instance of the model.
 
 #### `storeCacheForModel(model)`
-- **Description**: Returns the cache for a specific model. If no cache exists for the model, it initializes an empty array for it.
+
+- **Description**: Returns the cache for a specific model. If no cache exists for the model, it initializes an empty
+  array for it.
 - **Usage**: `storeService.storeCacheForModel('modelName');`
 - **Parameters**:
   - `model` (String): The given model.
 - **Returns**: An array representing the cache for the specified model.
 
 #### `peekInstance(model, uri)`
+
 - **Description**: Searches the cache for an instance of a model by URI.
 - **Usage**: `storeService.peekInstance('modelName', 'resourceUri');`
 - **Parameters**:
@@ -330,6 +367,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: The found instance or `undefined` if not found.
 
 #### `all(model, options)`
+
 - **Description**: Returns all instances of a model (type), optionally filtered by RDF type.
 - **Usage**: `storeService.all('modelName', { rdfType: 'http://example.com/type' });`
 - **Parameters**:
@@ -338,6 +376,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: An array of model instances.
 
 #### `classForModel(model)`
+
 - **Description**: Looks up a model class by name.
 - **Usage**: `storeService.classForModel('modelName');`
 - **Parameters**:
@@ -345,6 +384,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: The class constructor for the specified model.
 
 #### `fetchGraphForType(model)`
+
 - **Description**: Fetches the graph for a specific model (type) from the Solid pod.
 - **Usage**: `await storeService.fetchGraphForType('modelName');`
 - **Parameters**:
@@ -352,7 +392,9 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: promise that resolves when the graph is fetched.
 
 #### `discoverDefaultGraphByType(constructor, rdfType = constructor.rdfType)`
-- **Description**: Determines the default graph for a given model type, based on the model's configuration and the store's indexes.
+
+- **Description**: Determines the default graph for a given model type, based on the model's configuration and the
+  store's indexes.
 - **Usage**: `storeService.discoverDefaultGraphByType(ModelConstructor);`
 - **Parameters**:
   - `constructor` (Function): The constructor function of the model.
@@ -360,6 +402,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: A `NamedNode` representing the URI of the discovered default graph.
 
 #### `getGraphForType(type)`
+
 - **Description**: Retrieves the graph URI associated with a specific type.
 - **Usage**: `storeService.getGraphForType('typeUri');`
 - **Parameters**:
@@ -367,6 +410,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: The graph URI as a `NamedNode`.
 
 #### `getAutosaveForType(type)`
+
 - **Description**: Checks if a resource type needs to be autosaved.
 - **Usage**: `storeService.getAutosaveForType('typeUri');`
 - **Parameters**:
@@ -374,6 +418,7 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: A boolean indicating whether the type should be autosaved.
 
 #### `addChangeListener(listener)`
+
 - **Description**: Adds a change listener that will be notified of changes to the store.
 - **Usage**: `storeService.addChangeListener(listenerFunction);`
 - **Parameters**:
@@ -381,12 +426,12 @@ It provides methods to interact with the data from a Solid pod.
 - **Returns**: void.
 
 #### `removeChangeListener(listener)`
+
 - **Description**: Removes a previously registered change listener.
 - **Usage**: `storeService.removeChangeListener(listenerFunction);`
 - **Parameters**:
   - `listener` (Function): The listener to remove.
 - **Returns**: void.
-
 
 ### solid-Auth
 
@@ -394,7 +439,9 @@ The `solid-Auth` service used to log-in with solid and fetch profile-info and ty
 
 #### `restoreSession()`
 
-- **Description**: Attempts to restore a Solid session from a previous login. If a session is already present, it returns that session. Otherwise, it tries to handle an incoming redirect from the Solid identity provider, restoring the session if one was initiated before. It also sets up the RDF store with the session and pod base information.
+- **Description**: Attempts to restore a Solid session from a previous login. If a session is already present, it
+  returns that session. Otherwise, it tries to handle an incoming redirect from the Solid identity provider, restoring
+  the session if one was initiated before. It also sets up the RDF store with the session and pod base information.
 
 - **Usage**:`await authService.restoreSession();`
 - **Parameters**: None.
@@ -402,57 +449,59 @@ The `solid-Auth` service used to log-in with solid and fetch profile-info and ty
 - **Returns**: A `Promise` that resolves to the restored or current session.
 
 #### `ensureLogin()`
-- **Description**: Ensures that the user is logged in to their Solid pod. If the user is not logged in, it attempts to initiate the login process.
+
+- **Description**: Ensures that the user is logged in to their Solid pod. If the user is not logged in, it attempts to
+  initiate the login process.
 - **Usage**: `await storeService.ensureLogin();`
 - **Parameters**: None.
 - **Returns**: None. Updates the `authSession` property upon successful login.
 
 #### `ensureLogout()`
 
-- **Description**: Logs out of the current Solid session. This method checks if the user is currently logged in. If so, it performs the logout operation and removes the last identity provider from local storage.
+- **Description**: Logs out of the current Solid session. This method checks if the user is currently logged in. If so,
+  it performs the logout operation and removes the last identity provider from local storage.
 
 - **Usage**:
-`
-await authService.ensureLogout();
-`
+  `
+  await authService.ensureLogout();
+  `
 
 - **Parameters**: None.
 
-- **Returns**: A `Promise` that resolves when the logout operation has been completed and the session state has been cleared.
+- **Returns**: A `Promise` that resolves when the logout operation has been completed and the session state has been
+  cleared.
 
 #### `ensureTypeIndex()`
 
 - **Description**: Fetches profile-info and the private- and public type indexes and stores them in the RDF store.
 - **Usage**:
-`
-await authService.ensureTypeIndex();
-`
+  `
+  await authService.ensureTypeIndex();
+  `
 - **Parameters**: None.
 
 - **Returns**: A `Promise` that resolves when the type indexes have been loaded into the store.
 
-
 #### `getPodBase()`
 
 - **Description**: Retrieves the base URL of the user's Solid pod. Gets the pod base of the current user as a Promise.
-Will always end with a trailing slash.
-First, it will look for a pim:storage property on the webId.
-If not, it will look if the current queried resource is a pim:Storage resource, which is then our podBase.
-If not, it will look if the current queried resource is a lpd:BasicContainer resource, which is then our podBase.
-Otherwise, it will traverse upwards and do the same again.
+  Will always end with a trailing slash.
+  First, it will look for a pim:storage property on the webId.
+  If not, it will look if the current queried resource is a pim:Storage resource, which is then our podBase.
+  If not, it will look if the current queried resource is a lpd:BasicContainer resource, which is then our podBase.
+  Otherwise, it will traverse upwards and do the same again.
 - **Usage**:
-`
-const podBase = await authService.getPodBase(userWebId);
-`
+  `
+  const podBase = await authService.getPodBase(userWebId);
+  `
 - **Parameters**: None.
-**Returns**: A `Promise` that resolves to a string representing the base URL of the Solid pod, always ending with a trailing slash.
-
-
-
-
+  **Returns**: A `Promise` that resolves to a string representing the base URL of the Solid pod, always ending with a
+  trailing slash.
 
 #### `initializeSession()`
-- **Description**: Initializes the authentication session by checking if there's an existing session with the Solid server and setting the `authSession` property accordingly.
+
+- **Description**: Initializes the authentication session by checking if there's an existing session with the Solid
+  server and setting the `authSession` property accordingly.
 - **Usage**: `await storeService.initializeSession();`
 - **Parameters**: None.
 - **Returns**: None. Updates the `authSession` property of the `StoreService` instance.
@@ -464,7 +513,6 @@ const podBase = await authService.getPodBase(userWebId);
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ In a terminal, enter `ember new tutorial`.
 followed by `ember install https://github.com/redpencilio/ember-solid`
 and `ember generate ember-solid`
 
-first go into `templates/applications.hbs` and change it to this 
-```hbs
+first go into `templates/application.hbs` and change it to this 
+```html
 {{page-title "Tutorial on Ember-Solid"}}
 <h1>tutorial</h1>
 <LinkTo @route="authors">Authors</LinkTo>
@@ -35,13 +35,13 @@ first go into `templates/applications.hbs` and change it to this
 ```
 
 Now in a terminal type 
-`ember g route authors`
+`ember g route author`
 
-in `routes/authors.js` put
+in `routes/author.js` put
 ```js
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
-export default class AuthorsRoute extends Route {
+export default class AuthorRoute extends Route {
   @service solidAuth;
   @service store;
   async model() {
@@ -52,8 +52,8 @@ export default class AuthorsRoute extends Route {
 }
 
 ```
-And in `templates/authors.hbs` write
-```hbs
+And in `templates/author.hbs` write
+```html
 {{page-title "Authors"}}
 <h2>Authors</h2>
 <ul>
@@ -65,7 +65,7 @@ And in `templates/authors.hbs` write
 ```
 
 in a terminal type `ember g model author`
-and then in `models/authors` put
+and then in `models/author.js` put
 ```js
 import SemanticModel, {
   solid,
@@ -97,7 +97,365 @@ Now we should be able to log in and see the Authors stored in our solidpod
 
 ## how-to's
 
+### model a semantic model
+```js
+import SemanticModel, {
+  solid,
+  string,
+  integer,
+  hasMany,
+  belongsTo
+} from "ember-solid/models/semantic-model";
+
+@solid({
+  defaultStorageLocation: '/private/tests/my-books.ttl', // default location in solid pod
+  private: true, // is this private info for the user?
+  type: 'http://schema.org/Person', // optional, defining NS is good enough if this is derived from the namespace.
+  namespace: 'http://schema.org/', // define a namespace for properties.  http://schema.org/ is a good starting point for finding definitions.  No clue? use 'ext'.
+})
+
+export default class ourSemanticModel extends SemanticModel {
+  @string()
+  porperty1;
+}
+```
+
+### initiate the authentication service
+```js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service solidAuth;
+  async beforeModel() {
+    await this.solidAuth.ensureLogin();
+  }
+}
+
+```
+
+### Fetch solid store data
+
+```js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service solidAuth;
+  @service store;
+  async model() {
+    await this.solidAuth.ensureLogin();
+    await this.store.fetchGraphForType("author");
+    return this.store.all("author");
+  }
+}
+
+```
+
+### change the data locally
+
+```js
+
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service solidAuth;
+  @service store;
+  async model() {
+    await this.solidAuth.ensureLogin();
+    await this.store.fetchGraphForType("author");
+    return this.store.all("author");
+  }
+  async afterModel(model) {
+    model.forEach((author) => {
+      author.givenName = "new name";
+    });
+    this.router.refresh();
+  }
+}
+
+```
+
+### delete data locally
+  
+  ```js
+  import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service solidAuth;
+  @service store;
+  async model() {
+    await this.solidAuth.ensureLogin();
+    await this.store.fetchGraphForType("author");
+    return this.store.all("author");
+  }
+  async afterModel(model) {
+    model.forEach((author) => {
+      author.destroy();
+    });
+    this.router.refresh();
+  }
+}
+
+```
+
+
+### update the solid store
+
+```js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service solidAuth;
+  @service store;
+  async model() {
+    await this.solidAuth.ensureLogin();
+    await this.store.fetchGraphForType("author");
+    return this.store.all("author");
+  }
+  async afterModel(model) {
+    model.forEach((author) => {
+      author.givenName = "new name";
+    });
+    this.store.persist();
+    this.router.refresh();
+  }
+}
+
+```
+
+
 ## reference
+
+### semantic decorators
+
+
+#### `@rdfType(typeUri)`~
+Marks a class as representing a specific RDF type. This decorator assigns an RDF type URI to the class, which is used when instances of the class are stored or retrieved from the RDF store.
+
+```javascript
+@rdfType('http://example.com/Type')
+class MyModel extends SemanticModel {
+  // Class definition
+}
+```
+
+#### `@defaultGraph(graphUri)`~
+Specifies the default graph URI for all instances of the class. This is used to determine where in the RDF store the instances should be placed or retrieved from by default.
+
+```javascript
+@defaultGraph('http://example.com/graph')
+class MyModel extends SemanticModel {
+  // Class definition
+}
+```
+
+#### `@autosave(boolean)`~
+Enables or disables automatic saving of instances to the RDF store upon changes. When set to `true`, any change to an instance its properties will automatically trigger an update in the RDF store.
+
+```javascript
+@autosave(true)
+class MyModel extends SemanticModel {
+  // Class definition
+}
+```
+
+#### `@solid(options)`~
+Configures the solid integration with the class. This decorator can be used to set up a model class for use with Solid data pods.
+
+```javascript
+@solid({ defaultStorageLocation: '/private/myLocation', private: true, type: 'http://example.com/Type', namespace: 'http://example.com/' })
+class MyModel extends SemanticModel {
+  // Class definition
+}
+```
+
+#### Property Decorators~
+The file also introduces a set of property decorators, which are used to define the properties of the model classes. These decorators specify the type of the property, how it relates to RDF predicates, and other options like whether the property is a relation to another model.
+
+- `@property(options)`: Generic property decorator to define a model property.
+- `@string(options)`: Defines a string property.
+- `@stringSet(options)`: Defines a property that holds a set of strings.
+- `@uri(options)`: Defines a URI property.
+- `@decimal(options)`: Defines a decimal property.
+- `@integer(options)`: Defines an integer property.
+- `@float(options)`: Defines a float property.
+- `@boolean(options)`: Defines a boolean property.
+- `@dateTime(options)`: Defines a datetime property.
+- `@hasMany(options)`: Defines a relation to many instances of another model.
+- `@belongsTo(options)`: Defines a relation to a single instance of another model.
+- `@term(options)`: Defines a property that holds a term (NamedNode, BlankNode, or Literal).
+
+Each property decorator is used by specifying it above the property definition in the model class, providing options to configure the property's behavior and how it maps to RDF data.
+
+```javascript
+class MyModel extends SemanticModel {
+  @string()
+  name;
+
+  @hasMany({ model: 'OtherModel', inverse: 'parent' })
+  children;
+}
+```
+
+### rdf-store
+
+The `rdf-store` serves as the primary interface for interacting with Solid storage.
+It provides methods to interact with the data from a Solid pod.
+
+#### `create(model, options = {})`~
+- **Description**: Creates an instance of a model with a specific URI and saves it in the cache. If an instance with the same URI already exists in the cache, it returns the existing instance instead of creating a new one.
+- **Usage**: `storeService.create('modelName', { uri: 'resourceUri' });`
+- **Parameters**:
+  - `model` (String): Model to create an instance of.
+  - `options` ({uri: String}): Options including the URI of the resource.
+- **Returns**: An instance of the model.
+
+#### `storeCacheForModel(model)`~
+- **Description**: Returns the cache for a specific model. If no cache exists for the model, it initializes an empty array for it.
+- **Usage**: `storeService.storeCacheForModel('modelName');`
+- **Parameters**:
+  - `model` (String): The given model.
+- **Returns**: An array representing the cache for the specified model.
+
+#### `peekInstance(model, uri)`~
+- **Description**: Searches the cache for an instance of a model by URI.
+- **Usage**: `storeService.peekInstance('modelName', 'resourceUri');`
+- **Parameters**:
+  - `model` (String): The model.
+  - `uri` (String): The URI of the instance.
+- **Returns**: The found instance or `undefined` if not found.
+
+#### `all(model, options)`~
+- **Description**: Returns all instances of a model (type), optionally filtered by RDF type.
+- **Usage**: `storeService.all('modelName', { rdfType: 'http://example.com/type' });`
+- **Parameters**:
+  - `model` (String): The given model.
+  - `options` (Object): Options including the RDF type of the instances to return.
+- **Returns**: An array of model instances.
+
+#### `classForModel(model)`~
+- **Description**: Looks up a model class by name.
+- **Usage**: `storeService.classForModel('modelName');`
+- **Parameters**:
+  - `model` (String): Name of the model to lookup.
+- **Returns**: The class constructor for the specified model.
+
+#### `fetchGraphForType(model)`~
+- **Description**: Fetches the graph for a specific model (type) from the Solid pod.
+- **Usage**: `await storeService.fetchGraphForType('modelName');`
+- **Parameters**:
+  - `model` (String): The given model.
+- **Returns**: promise that resolves when the graph is fetched.
+
+#### `discoverDefaultGraphByType(constructor, rdfType = constructor.rdfType)`
+- **Description**: Determines the default graph for a given model type, based on the model's configuration and the store's indexes.
+- **Usage**: `storeService.discoverDefaultGraphByType(ModelConstructor);`
+- **Parameters**:
+  - `constructor` (Function): The constructor function of the model.
+  - `rdfType` (NamedNode, optional): The RDF type of the model.
+- **Returns**: A `NamedNode` representing the URI of the discovered default graph.
+
+#### `getGraphForType(type)`
+- **Description**: Retrieves the graph URI associated with a specific type.
+- **Usage**: `storeService.getGraphForType('typeUri');`
+- **Parameters**:
+  - `type` (String): The type to check.
+- **Returns**: The graph URI as a `NamedNode`.
+
+#### `getAutosaveForType(type)`~
+- **Description**: Checks if a resource type needs to be autosaved.
+- **Usage**: `storeService.getAutosaveForType('typeUri');`
+- **Parameters**:
+  - `type` (String): The type to check.
+- **Returns**: A boolean indicating whether the type should be autosaved.
+
+#### `addChangeListener(listener)`~
+- **Description**: Adds a change listener that will be notified of changes to the store.
+- **Usage**: `storeService.addChangeListener(listenerFunction);`
+- **Parameters**:
+  - `listener` (callback): The function to be called when changes occur.
+- **Returns**: void.
+
+#### `removeChangeListener(listener)`~
+- **Description**: Removes a previously registered change listener.
+- **Usage**: `storeService.removeChangeListener(listenerFunction);`
+- **Parameters**:
+  - `listener` (Function): The listener to remove.
+- **Returns**: void.
+
+
+### solid-Auth
+
+The `solid-Auth` service used to log-in with solid and fetch profile-info and type-inde
+
+#### `restoreSession()`~
+
+- **Description**: Attempts to restore a Solid session from a previous login. If a session is already present, it returns that session. Otherwise, it tries to handle an incoming redirect from the Solid identity provider, restoring the session if one was initiated before. It also sets up the RDF store with the session and pod base information.
+
+- **Usage**:`await authService.restoreSession();`
+- **Parameters**: None.
+
+- **Returns**: A `Promise` that resolves to the restored or current session.
+
+#### `ensureLogin()`~
+- **Description**: Ensures that the user is logged in to their Solid pod. If the user is not logged in, it attempts to initiate the login process.
+- **Usage**: `await storeService.ensureLogin();`
+- **Parameters**: None.
+- **Returns**: None. Updates the `authSession` property upon successful login.
+
+#### `ensureLogout()`
+
+- **Description**: Logs out of the current Solid session. This method checks if the user is currently logged in. If so, it performs the logout operation and removes the last identity provider from local storage.
+
+- **Usage**:
+`
+await authService.ensureLogout();
+`
+
+- **Parameters**: None.
+
+- **Returns**: A `Promise` that resolves when the logout operation has been completed and the session state has been cleared.
+
+#### `ensureTypeIndex()`
+
+- **Description**: Fetches profile-info and the private- and public type indexes and stores them in the RDF store.
+- **Usage**:
+`
+await authService.ensureTypeIndex();
+`
+- **Parameters**: None.
+
+- **Returns**: A `Promise` that resolves when the type indexes have been loaded into the store.
+
+
+#### `getPodBase()`
+
+- **Description**: Retrieves the base URL of the user's Solid pod. Gets the pod base of the current user as a Promise.
+Will always end with a trailing slash.
+First, it will look for a pim:storage property on the webId.
+If not, it will look if the current queried resource is a pim:Storage resource, which is then our podBase.
+If not, it will look if the current queried resource is a lpd:BasicContainer resource, which is then our podBase.
+Otherwise, it will traverse upwards and do the same again.
+- **Usage**:
+`
+const podBase = await authService.getPodBase(userWebId);
+`
+- **Parameters**: None.
+**Returns**: A `Promise` that resolves to a string representing the base URL of the Solid pod, always ending with a trailing slash.
+
+
+
+
+
+#### `initializeSession()`
+- **Description**: Initializes the authentication session by checking if there's an existing session with the Solid server and setting the `authSession` property accordingly.
+- **Usage**: `await storeService.initializeSession();`
+- **Parameters**: None.
+- **Returns**: None. Updates the `authSession` property of the `StoreService` instance.
 
 ## discussion
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,14 @@ The `solid-Auth` service used to log-in with solid and fetch profile-info and ty
 
 ## discussion
 
+### Experimental Branch for Triplestore Support
+
+An experimental branch introduces support for using a triplestore alongside Solid Pods.
+
+For more details on the purpose and implementation, please refer to the [discussion section in the experimental branch](https://github.com/redpencilio/ember-solid/tree/experimental/triplestore?tab=readme-ov-file#further-changes-to-make-triplestore-integration-viable).
+
+
+
 ### Solid
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ export default class ApplicationRoute extends Route {
 ### semantic decorators
 
 
-#### `@rdfType(typeUri)`~
+#### `@rdfType(typeUri)`
 Marks a class as representing a specific RDF type. This decorator assigns an RDF type URI to the class, which is used when instances of the class are stored or retrieved from the RDF store.
 
 ```javascript
@@ -243,7 +243,7 @@ class MyModel extends SemanticModel {
 }
 ```
 
-#### `@defaultGraph(graphUri)`~
+#### `@defaultGraph(graphUri)`
 Specifies the default graph URI for all instances of the class. This is used to determine where in the RDF store the instances should be placed or retrieved from by default.
 
 ```javascript
@@ -253,7 +253,7 @@ class MyModel extends SemanticModel {
 }
 ```
 
-#### `@autosave(boolean)`~
+#### `@autosave(boolean)`
 Enables or disables automatic saving of instances to the RDF store upon changes. When set to `true`, any change to an instance its properties will automatically trigger an update in the RDF store.
 
 ```javascript
@@ -263,7 +263,7 @@ class MyModel extends SemanticModel {
 }
 ```
 
-#### `@solid(options)`~
+#### `@solid(options)`
 Configures the solid integration with the class. This decorator can be used to set up a model class for use with Solid data pods.
 
 ```javascript
@@ -273,7 +273,7 @@ class MyModel extends SemanticModel {
 }
 ```
 
-#### Property Decorators~
+#### Property Decorators
 The file also introduces a set of property decorators, which are used to define the properties of the model classes. These decorators specify the type of the property, how it relates to RDF predicates, and other options like whether the property is a relation to another model.
 
 - `@property(options)`: Generic property decorator to define a model property.
@@ -306,7 +306,7 @@ class MyModel extends SemanticModel {
 The `rdf-store` serves as the primary interface for interacting with Solid storage.
 It provides methods to interact with the data from a Solid pod.
 
-#### `create(model, options = {})`~
+#### `create(model, options = {})`
 - **Description**: Creates an instance of a model with a specific URI and saves it in the cache. If an instance with the same URI already exists in the cache, it returns the existing instance instead of creating a new one.
 - **Usage**: `storeService.create('modelName', { uri: 'resourceUri' });`
 - **Parameters**:
@@ -314,14 +314,14 @@ It provides methods to interact with the data from a Solid pod.
   - `options` ({uri: String}): Options including the URI of the resource.
 - **Returns**: An instance of the model.
 
-#### `storeCacheForModel(model)`~
+#### `storeCacheForModel(model)`
 - **Description**: Returns the cache for a specific model. If no cache exists for the model, it initializes an empty array for it.
 - **Usage**: `storeService.storeCacheForModel('modelName');`
 - **Parameters**:
   - `model` (String): The given model.
 - **Returns**: An array representing the cache for the specified model.
 
-#### `peekInstance(model, uri)`~
+#### `peekInstance(model, uri)`
 - **Description**: Searches the cache for an instance of a model by URI.
 - **Usage**: `storeService.peekInstance('modelName', 'resourceUri');`
 - **Parameters**:
@@ -329,7 +329,7 @@ It provides methods to interact with the data from a Solid pod.
   - `uri` (String): The URI of the instance.
 - **Returns**: The found instance or `undefined` if not found.
 
-#### `all(model, options)`~
+#### `all(model, options)`
 - **Description**: Returns all instances of a model (type), optionally filtered by RDF type.
 - **Usage**: `storeService.all('modelName', { rdfType: 'http://example.com/type' });`
 - **Parameters**:
@@ -337,14 +337,14 @@ It provides methods to interact with the data from a Solid pod.
   - `options` (Object): Options including the RDF type of the instances to return.
 - **Returns**: An array of model instances.
 
-#### `classForModel(model)`~
+#### `classForModel(model)`
 - **Description**: Looks up a model class by name.
 - **Usage**: `storeService.classForModel('modelName');`
 - **Parameters**:
   - `model` (String): Name of the model to lookup.
 - **Returns**: The class constructor for the specified model.
 
-#### `fetchGraphForType(model)`~
+#### `fetchGraphForType(model)`
 - **Description**: Fetches the graph for a specific model (type) from the Solid pod.
 - **Usage**: `await storeService.fetchGraphForType('modelName');`
 - **Parameters**:
@@ -366,21 +366,21 @@ It provides methods to interact with the data from a Solid pod.
   - `type` (String): The type to check.
 - **Returns**: The graph URI as a `NamedNode`.
 
-#### `getAutosaveForType(type)`~
+#### `getAutosaveForType(type)`
 - **Description**: Checks if a resource type needs to be autosaved.
 - **Usage**: `storeService.getAutosaveForType('typeUri');`
 - **Parameters**:
   - `type` (String): The type to check.
 - **Returns**: A boolean indicating whether the type should be autosaved.
 
-#### `addChangeListener(listener)`~
+#### `addChangeListener(listener)`
 - **Description**: Adds a change listener that will be notified of changes to the store.
 - **Usage**: `storeService.addChangeListener(listenerFunction);`
 - **Parameters**:
   - `listener` (callback): The function to be called when changes occur.
 - **Returns**: void.
 
-#### `removeChangeListener(listener)`~
+#### `removeChangeListener(listener)`
 - **Description**: Removes a previously registered change listener.
 - **Usage**: `storeService.removeChangeListener(listenerFunction);`
 - **Parameters**:
@@ -392,7 +392,7 @@ It provides methods to interact with the data from a Solid pod.
 
 The `solid-Auth` service used to log-in with solid and fetch profile-info and type-inde
 
-#### `restoreSession()`~
+#### `restoreSession()`
 
 - **Description**: Attempts to restore a Solid session from a previous login. If a session is already present, it returns that session. Otherwise, it tries to handle an incoming redirect from the Solid identity provider, restoring the session if one was initiated before. It also sets up the RDF store with the session and pod base information.
 
@@ -401,7 +401,7 @@ The `solid-Auth` service used to log-in with solid and fetch profile-info and ty
 
 - **Returns**: A `Promise` that resolves to the restored or current session.
 
-#### `ensureLogin()`~
+#### `ensureLogin()`
 - **Description**: Ensures that the user is logged in to their Solid pod. If the user is not logged in, it attempts to initiate the login process.
 - **Usage**: `await storeService.ensureLogin();`
 - **Parameters**: None.


### PR DESCRIPTION
The documentation uses the [Divio documentation-system ](https://docs.divio.com/documentation-system/)

Key updates:

- Tutorial: Step-by-step guide to set up and use Ember-Solid, including creating a simple page to display authors from a Solid Pod.
- How-to Guides: Instructions on modeling semantic models, initiating the authentication service, fetching data, changing data locally, deleting data locally, and updating the Solid store.
- Reference: Descriptions of semantic decorators, property decorators, and methods provided by the rdf-store and solid-Auth services.
- Discussion: Information about the experimental branch for triplestore support.